### PR TITLE
Single cycle bugfix

### DIFF
--- a/dataPath.v
+++ b/dataPath.v
@@ -59,12 +59,12 @@ module dataPath(
   ALU alu(ALU_out, carryout, ovf, zero, A, B, ALU_ctrl);
 
   // Set up data memory
-  dataMemory #(32,2**32,32) data_mem (mem_dout, ALU_out, mem_wr, Db, clk);
+  dataMemory #(32,32'h4000,32) data_mem (mem_dout, ALU_out, mem_wr, Db, clk);
 
   // Set up load/result mux
   assign writeback = mem_to_reg ? mem_dout : ALU_out;
 
-  
+
 
 
 

--- a/instructionFetch.v
+++ b/instructionFetch.v
@@ -1,9 +1,9 @@
 `include "regfile-dependencies/register32.v"
 `include "signExtend.v"
 `include "alu.v"
-`include "InstructionMemory.v"
+`include "instructionMemory.v"
 
-module InstructionFetch
+module instructionFetch
 (
   output[31:0] Instr,
   output[31:0] PC,
@@ -27,7 +27,7 @@ module InstructionFetch
   //wire nextAddr;
   register32 PC_module (PC, newAddr, 1'b1, clk);
   signExtend IF_SE (signextimm, Imm16, 1'b0);
-  InstructionMemory InstMem(Instr, {PC[31:2], 2'b00}, clk);
+  instructionMemory InstMem(Instr, {PC[31:2], 2'b00}, clk);
   assign jumpaddr = {PC[31:28],TargetAddr, 2'b00};
   assign muxsig1 = (!zero && Branch);
   assign addunit = muxsig1 ? signextimm : 32'b0;

--- a/instructionFetch.v
+++ b/instructionFetch.v
@@ -1,6 +1,5 @@
 `include "regfile-dependencies/register32.v"
 `include "signExtend.v"
-`include "alu.v"
 `include "instructionMemory.v"
 
 module instructionFetch

--- a/instructionMemory.v
+++ b/instructionMemory.v
@@ -1,4 +1,4 @@
-module InstructionMemory
+module instructionMemory
 (
   output[31:0]  DataOut,
   //input regWE, //for actual memory


### PR DESCRIPTION
Three bug fixes:
- Enforce file name convention
- Reduce size of data memory
- Remove unnecessary ALU include

Still has warnings: redefining modules register32 and signExtend in final `singleCycleCPU.v` (separate includes in `instructionFetch.v` and `dataPath.v`